### PR TITLE
Consumo de API via CEP

### DIFF
--- a/M01S06/ExercicioSete/seis.html
+++ b/M01S06/ExercicioSete/seis.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=>, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+   <script src="seis.js"></script> 
+</body>
+</html>

--- a/M01S06/ExercicioSete/seis.js
+++ b/M01S06/ExercicioSete/seis.js
@@ -1,0 +1,12 @@
+let cep = prompt("Digite seu CEP:");
+
+fetch(`https://viacep.com.br/ws/${cep}/json`, { method: "GET" })
+  .then((retornoFetch) => {
+    return retornoFetch.json();
+  })
+  .then((retornoApi) => {
+    // “logradouro, complemento - bairro - localidade/uf”
+
+    alert(`${retornoApi.logradouro}, ${retornoApi.complemento} -
+    ${retornoApi.bairro} - ${retornoApi.localidade}/${retornoApi.uf}`);
+  });


### PR DESCRIPTION
Para treinar um pouco mais requisições fetch inicie uma comunicação com a API via cep (Documentação - [ViaCEP - Webservice CEP e IBGE gratuito](https://viacep.com.br/) ).
OBS:

Crie uma página html para imprimir o endereço através do cep.

Utilize este endpoint: [https://viacep.com.br/ws/{cep_informado}/json](https://viacep.com.br/ws/01001000/json/)

Caso a api retorne sucesso imprima em um alert o endereço formatado da seguinte forma: “logradouro, complemento - bairro - localidade/uf”

o cep_informado será passado por prompt pelo usuário.